### PR TITLE
Fix broken registration of 'emqttd' process

### DIFF
--- a/src/emqttd_app.erl
+++ b/src/emqttd_app.erl
@@ -52,7 +52,7 @@ start(_Type, _Args) ->
                            {?MODULE,register_acl_mod,[]},
                            {emqttd_plugins,init,[]},
                            {?MODULE,start_listeners,[]},
-                           {register,[emqttd, self()]}] ],
+                           {erlang, register,[emqttd, self()]}] ],
     print_vsn(),
     {ok, Sup}.
 


### PR DESCRIPTION
This will also make `emqttd:is_running/1` work.